### PR TITLE
Changes to make the plugin build in the latest Gradle

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -2,10 +2,10 @@ group 'de.appgewaltig.disk_space'
 version '1.0-SNAPSHOT'
 
 buildscript {
-    ext.kotlin_version = '1.3.72'
+    ext.kotlin_version = '1.5.20'
     repositories {
         google()
-        jcenter()
+        mavenCentral()
     }
 
     dependencies {
@@ -26,6 +26,10 @@ apply plugin: 'kotlin-android'
 
 android {
     compileSdkVersion 30
+
+    if (project.android.hasProperty("namespace")) {
+        namespace 'de.appgewaltig.disk_space'
+    }
 
     sourceSets {
         main.java.srcDirs += 'src/main/kotlin'


### PR DESCRIPTION
1. Kotlin version changed to 1.5.20
2. jcenter repository changed to mavenCentral (as jcenter does not exist anymore)
3. Namespace specified explicitly